### PR TITLE
Remove redis-cli from alimalinux images

### DIFF
--- a/lifeboat/almalinux/Dockerfile.8.x
+++ b/lifeboat/almalinux/Dockerfile.8.x
@@ -34,12 +34,12 @@ RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.n
 
 RUN dnf -y install mysql postgresql
 
-RUN wget http://download.redis.io/redis-stable.tar.gz \
-      && tar xvzf redis-stable.tar.gz \
-      && cd redis-stable \
-      && make distclean \
-      && make \
-      && cp src/redis-cli /usr/local/bin/ \
-      && chmod 755 /usr/local/bin/redis-cli
+#RUN wget http://download.redis.io/redis-stable.tar.gz \
+#      && tar xvzf redis-stable.tar.gz \
+#      && cd redis-stable \
+#      && make distclean \
+#      && make \
+#      && cp src/redis-cli /usr/local/bin/ \
+#      && chmod 755 /usr/local/bin/redis-cli
 
 RUN dnf clean all

--- a/lifeboat/almalinux/Dockerfile.9.x
+++ b/lifeboat/almalinux/Dockerfile.9.x
@@ -34,12 +34,12 @@ RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.n
 
 RUN dnf -y install mysql postgresql
 
-RUN wget http://download.redis.io/redis-stable.tar.gz \
-      && tar xvzf redis-stable.tar.gz \
-      && cd redis-stable \
-      && make distclean \
-      && make \
-      && cp src/redis-cli /usr/local/bin/ \
-      && chmod 755 /usr/local/bin/redis-cli
+#RUN wget http://download.redis.io/redis-stable.tar.gz \
+#      && tar xvzf redis-stable.tar.gz \
+#      && cd redis-stable \
+#      && make distclean \
+#      && make \
+#      && cp src/redis-cli /usr/local/bin/ \
+#      && chmod 755 /usr/local/bin/redis-cli
 
 RUN dnf clean all


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Removed Redis installation and setup from Almalinux Docker configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->