### PR TITLE
Remove needless tagname

### DIFF
--- a/lifeboat/almalinux/makefile
+++ b/lifeboat/almalinux/makefile
@@ -1,7 +1,5 @@
 SHELL=/bin/bash
 
-TAG_NAME = 0.0.1
-
 test-build:
 	docker build -t almalinux-lifeboat:8.9 -f Dockerfile.8.x .
 	docker build -t almalinux-lifeboat:9.3 -f Dockerfile.9.x .

--- a/lifeboat/ubuntu/makefile
+++ b/lifeboat/ubuntu/makefile
@@ -1,7 +1,5 @@
 SHELL=/bin/bash
 
-TAG_NAME = 0.0.1
-
 test-build: Dockerfile
 	docker build --no-cache -t ubuntu-lifeboat:latest .
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed the `TAG_NAME` variable from the makefiles for AlmaLinux and Ubuntu, simplifying build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->