### PR TITLE
Lunar version excluded from updates

### DIFF
--- a/lifeboat/ubuntu/release.multi-arch.mac.sh
+++ b/lifeboat/ubuntu/release.multi-arch.mac.sh
@@ -41,17 +41,6 @@ docker buildx build --push --platform=linux/arm64,linux/amd64,linux/s390x,linux/
 
 
 ####################################################
-# lunar
-####################################################
-######### Docker Hub #########
-docker buildx build --push --platform=linux/arm64,linux/amd64,linux/s390x,linux/ppc64le --tag doridoridoriand/lifeboat-ubuntu:lunar-$unixtime \
-                                                                                        --tag doridoridoriand/lifeboat-ubuntu:lunar-latest -f Dockerfile.lunar .
-
-######### GitHub Packages #########
-docker buildx build --push --platform=linux/arm64,linux/amd64,linux/s390x,linux/ppc64le --tag ghcr.io/doridoridoriand/containers/lifeboat-ubuntu:lunar-$unixtime \
-                                                                                        --tag ghcr.io/doridoridoriand/containers/lifeboat-ubuntu:lunar-latest -f Dockerfile.lunar .
-
-####################################################
 # noble
 ####################################################
 ######### Docker Hub #########


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed outdated build instructions for the "lunar" version of lifeboat-ubuntu Docker images, streamlining the process to focus solely on the "jammy" version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->