### PR TITLE
Add ubuntu rolling to build target.

### DIFF
--- a/lifeboat/ubuntu/release.multi-arch.mac.sh
+++ b/lifeboat/ubuntu/release.multi-arch.mac.sh
@@ -53,4 +53,15 @@ docker buildx build --push --platform=linux/arm64,linux/amd64,linux/s390x,linux/
                                                                                         --tag ghcr.io/doridoridoriand/containers/lifeboat-ubuntu:noble-latest \
                                                                                         --tag ghcr.io/doridoridoriand/containers/lifeboat-ubuntu:latest -f Dockerfile.noble .
 
+####################################################
+# rolling
+####################################################
+######### Docker Hub #########
+docker buildx build --push --platform=linux/arm64,linux/amd64,linux/s390x,linux/ppc64le --tag doridoridoriand/lifeboat-ubuntu:rolling-$unixtime \
+                                                                                        --tag doridoridoriand/lifeboat-ubuntu:rolling-latest -f Dockerfile.rolling .
+
+######### GitHub Packages #########
+docker buildx build --push --platform=linux/arm64,linux/amd64,linux/s390x,linux/ppc64le --tag ghcr.io/doridoridoriand/containers/lifeboat-ubuntu:rolling-$unixtime \
+                                                                                        --tag ghcr.io/doridoridoriand/containers/lifeboat-ubuntu:rolling-latest -f Dockerfile.rolling .
+
 docker buildx rm ${BUIDX_NAME}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for building and pushing Docker images for a "rolling" version of the lifeboat-ubuntu container, enhancing deployment flexibility.
  
- **Bug Fixes**
	- No changes made that affect existing functionalities; error handling remains intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->