### PR TITLE
Update ruby version. Tweak script

### DIFF
--- a/boring_primenumber/Dockerfile
+++ b/boring_primenumber/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.0.0
+FROM ruby:3.0.1
 
 COPY . .
 CMD ruby exec.rb 1000000

--- a/boring_primenumber/Dockerfile
+++ b/boring_primenumber/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.8
+FROM ruby:3.0.0
 
 COPY . .
 CMD ruby exec.rb 1000000

--- a/boring_primenumber/release.multi-arch.sh
+++ b/boring_primenumber/release.multi-arch.sh
@@ -9,6 +9,7 @@ if ! docker info >/dev/null 2>&1; then
   exit 1
 fi
 
+RUBY_VERSION=3.0.0
 VERSION=0.0.2
 
 BUILDX_ALREADY_EXISTS=$(docker buildx ls 2>&1 | grep ${BUILDX_NAME}) || true;
@@ -21,7 +22,7 @@ docker login;
 docker buildx create --name ${BUILDX_NAME}
 docker buildx use ${BUILDX_NAME}
 
-docker buildx build --push --platform=linux/arm64,linux/amd64,linux/s390x,linux/ppc64le --tag doridoridoriand/waste_cpu_resource:2.7.8-$VERSION \
-                                                                                        --tag doridoridoriand/waste_cpu_resource:latest -f Dockerfile .
+docker buildx build --push --platform=linux/arm64,linux/amd64,linux/s390x,linux/ppc64le --tag doridoridoriand/boring_primenumber:$RUBY_VERSION-$VERSION \
+                                                                                        --tag doridoridoriand/boring_primenumber:latest -f Dockerfile .
 
 docker buildx rm ${BUILDX_NAME}

--- a/boring_primenumber/release.multi-arch.sh
+++ b/boring_primenumber/release.multi-arch.sh
@@ -9,8 +9,8 @@ if ! docker info >/dev/null 2>&1; then
   exit 1
 fi
 
-RUBY_VERSION=3.0.1
-VERSION=0.0.1
+RUBY_VERSION=${RUBY_VERSION:-3.0.1}
+VERSION=${VERSION:-0.0.1}
 
 BUILDX_ALREADY_EXISTS=$(docker buildx ls 2>&1 | grep ${BUILDX_NAME}) || true;
 

--- a/boring_primenumber/release.multi-arch.sh
+++ b/boring_primenumber/release.multi-arch.sh
@@ -9,8 +9,8 @@ if ! docker info >/dev/null 2>&1; then
   exit 1
 fi
 
-RUBY_VERSION=3.0.0
-VERSION=0.0.2
+RUBY_VERSION=3.0.1
+VERSION=0.0.1
 
 BUILDX_ALREADY_EXISTS=$(docker buildx ls 2>&1 | grep ${BUILDX_NAME}) || true;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Upgraded container runtime to Ruby 3.0.1 for improved compatibility and performance.
  - Docker image repository and tagging updated: images now use the boring_primenumber repository and include the Ruby version in tags (e.g., 3.0.1-0.0.1); the latest tag remains available.
  - Multi-architecture build and release flow unchanged; users relying on latest tag need no action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->