### PR TITLE
Tweak script

### DIFF
--- a/jmeter-standalone/release.sh
+++ b/jmeter-standalone/release.sh
@@ -1,13 +1,20 @@
-#!/bin/bash
+#!/usr/bin/env zsh
 
 set -eu
 
-unixtime=`date +%s`;
+VERSION=${VERSION:-5.6.3}
 
+wget https://dlcdn.apache.org/jmeter/binaries/apache-jmeter-${VERSION}.tgz
+tar zxvf apache-jmeter-${VERSION}.tgz
+
+docker build -t jmeter-standalone:${VERSION} .
+
+docker tag `docker images jmeter-standalone:latest --format "{{.ID}}"` ghcr.io/doridoridoriand/containers/jmeter-standalone:$VERSION;
 docker tag `docker images jmeter-standalone:latest --format "{{.ID}}"` ghcr.io/doridoridoriand/containers/jmeter-standalone:latest;
-docker tag `docker images jmeter-standalone:latest --format "{{.ID}}"` ghcr.io/doridoridoriand/containers/jmeter-standalone:$unixtime;
 
 cat ~/GH_TOKEN.txt | docker login ghcr.io -u doridoridoriand --password-stdin;
 
+docker push ghcr.io/doridoridoriand/containers/jmeter-standalone:$VERSION;
 docker push ghcr.io/doridoridoriand/containers/jmeter-standalone:latest;
-docker push ghcr.io/doridoridoriand/containers/jmeter-standalone:$unixtime;
+
+rm -rf apache-jmeter-*

--- a/jmeter-standalone/release.sh
+++ b/jmeter-standalone/release.sh
@@ -7,10 +7,11 @@ VERSION=${VERSION:-5.6.3}
 wget https://dlcdn.apache.org/jmeter/binaries/apache-jmeter-${VERSION}.tgz
 tar zxvf apache-jmeter-${VERSION}.tgz
 
-docker build -t jmeter-standalone:${VERSION} .
-
-docker tag `docker images jmeter-standalone:latest --format "{{.ID}}"` ghcr.io/doridoridoriand/containers/jmeter-standalone:$VERSION;
-docker tag `docker images jmeter-standalone:latest --format "{{.ID}}"` ghcr.io/doridoridoriand/containers/jmeter-standalone:latest;
+docker build \
+  -t jmeter-standalone:${VERSION} \
+  -t ghcr.io/doridoridoriand/containers/jmeter-standalone:${VERSION} \
+  -t ghcr.io/doridoridoriand/containers/jmeter-standalone:latest \
+  .
 
 cat ~/GH_TOKEN.txt | docker login ghcr.io -u doridoridoriand --password-stdin;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Release script now runs with Zsh and uses a standardized default version.
  - Automates building and publishing Docker images with both versioned and latest tags to the container registry.
  - Removed legacy timestamp-based image tagging.
  - Ensures registry authentication before pushing images.
  - Cleans up downloaded temporary artifacts after release to reduce workspace clutter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->